### PR TITLE
Add CONTRIBUTING.md for contribution guidelines (Hacktoberfest)

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -39,7 +39,7 @@ Any code contribution (bug fix or new feature) **must** include working tests.
 ## 🤝 Submitting Your Pull Request (PR)
 
 1.  Keep your PR focused on a single change.
-2.  Write a clear, brief PR title (e.g., `feat: Add support for [New API Feature]`).
+2.  Write a clear, brief PR title in the imperative mood (e.g., `Add support for [New API Feature]`).
 3.  In the PR description, explain **what** was changed and **why** it benefits the project.
 4.  If you are contributing for Hacktoberfest, feel free to mention it!
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,46 @@
+# Contributing to nextdns
+
+Welcome! We appreciate your interest in contributing to this Python wrapper for the NextDNS API. This project is actively maintained and welcomes contributions of all types—code, documentation, and feature ideas.
+
+**This repository participates in Hacktoberfest!** We encourage beginners to get involved.
+
+## 🚀 Ways to Contribute
+
+There are several ways you can help improve `nextdns`:
+
+1.  **Code (Bugs & Features):** Fix a reported bug or implement a new feature (like supporting a new API endpoint). All new code requires corresponding unit tests.
+2.  **Documentation:** Improve the clarity of the `README.md`, docstrings, or the `example.py`.
+3.  **Code Maintenance:** Fix linting/style issues identified by `ruff`, or update dependencies in `pyproject.toml` (always check for breaking changes first!).
+
+## 💡 Quick Start Checklist
+
+To ensure your contribution is merged smoothly, please follow these steps:
+
+1.  **Discuss First:** If you plan a large change or new feature, **please open an issue first** to discuss the idea with the maintainer.
+2.  **Fork and Clone:** Fork the repository and clone your fork locally.
+3.  **Create a New Branch:** Base your work on the `master` branch and create a new, descriptive branch (e.g., `feat/add-new-endpoint` or `fix/connection-bug`).
+
+## 🛠️ Development Setup & Testing
+
+### Environment and Style
+
+We use **Ruff** for linting and code formatting (as seen in `pyproject.toml`). Please ensure your code meets the standard:
+
+1.  **Format your code** before committing.
+2.  Use clear, descriptive commit messages (e.g., `fix: Corrected error handling in connection.py`).
+
+### Running Tests
+
+Any code contribution (bug fix or new feature) **must** include working tests.
+
+1.  Place new test files or logic inside the **`tests/`** directory.
+2.  Ensure all existing and new tests pass before submitting your PR.
+
+## 🤝 Submitting Your Pull Request (PR)
+
+1.  Keep your PR focused on a single change.
+2.  Write a clear, brief PR title (e.g., `feat: Add support for [New API Feature]`).
+3.  In the PR description, explain **what** was changed and **why** it benefits the project.
+4.  If you are contributing for Hacktoberfest, feel free to mention it!
+
+Thank you for helping make `nextdns` better!


### PR DESCRIPTION
Added a contributing guide to helpHello @bieniu!

I noticed this repository is participating in Hacktoberfest but was missing a contribution guide.

This Pull Request adds a comprehensive **`CONTRIBUTING.md`** file to:
1.  **Guide new contributors** on how to set up their development environment.
2.  **Ensure all code contributions include tests** and adhere to the project's formatting standards (using Ruff).
3.  **Encourage quality contributions** for the Hacktoberfest event.

This should be a clean merge. Let me know if you'd like any adjustments! new contributors understand how to participate in the project.